### PR TITLE
Update namers

### DIFF
--- a/dep_tools/namers.py
+++ b/dep_tools/namers.py
@@ -19,12 +19,14 @@ class GenericItemPath(ItemPath):
         time: str,
         prefix: str = "dep",
         zero_pad_numbers: bool = True,
+        folder: str = None,
     ):
         self.sensor = sensor
         self.dataset_id = dataset_id
         self.version = version
         self.time = time
         self.prefix = prefix
+        self.folder = folder
         self.zero_pad_numbers = zero_pad_numbers
         self.version = self.version.replace(".", "-")
         self._folder_prefix = (
@@ -54,8 +56,12 @@ class GenericItemPath(ItemPath):
         return join_str.join(item_parts)
 
     def _folder(self, item_id) -> str:
-        return f"{self._folder_prefix}/{self._format_item_id(item_id)}/{self.time}"
-
+        return (
+            f"{self._folder_prefix}/{self._format_item_id(item_id)}/{self.time}"
+            if self.folder is None
+            else f"{self.folder}/{self._folder_prefix}/{self._format_item_id(item_id)}/{self.time}"
+        )
+    
     def basename(self, item_id) -> str:
         return f"{self.item_prefix}_{self._format_item_id(item_id, join_str='_')}_{self.time}"
 
@@ -87,6 +93,7 @@ class S3ItemPath(GenericItemPath):
         time: str,
         prefix: str = "dep",
         zero_pad_numbers: bool = True,
+        bucket_prefix: str = None
     ):
         super().__init__(
             sensor=sensor,
@@ -95,6 +102,7 @@ class S3ItemPath(GenericItemPath):
             time=time,
             prefix=prefix,
             zero_pad_numbers=zero_pad_numbers,
+            folder=bucket_prefix,
         )
         self.bucket = bucket
 


### PR DESCRIPTION
Prefix isn't really an object prefix as it's used twice, in both the naming of the object itself and a 2nd time in the object key (path).
If we want to add a prefix to the key/path only, we need a 2nd argument
